### PR TITLE
(refactor) add heroku for api path

### DIFF
--- a/movieDash/www/js/services.js
+++ b/movieDash/www/js/services.js
@@ -14,7 +14,7 @@ app.factory('MovieClient', ['$http', 'selected', function($http, selected) {
     return $http({
       method: 'POST',
       data: query,
-      url: '/api/movies',
+      url: 'http://movie-dash.herokuapp.com/api/movies',
       success: function(response) {
          return response;
       },


### PR DESCRIPTION
change the path for the ajax request in services.js to the deployed heroku app
current bug: CORS
