### PR TITLE
(refactor) Fix path for trailer modal

### DIFF
--- a/movieDash/www/css/style.css
+++ b/movieDash/www/css/style.css
@@ -200,6 +200,19 @@ select {
   text-transform: uppercase;
 }
 
+.video { position: relative; }
+
+.video a {
+   position: absolute;
+   display: block;
+   background-color: blue;
+/*   background: url(url_to_play_button_image.png);
+*/   height: 40px;
+   width: 40px;
+   top: 20px;
+   left: 20px;
+}
+
 .modal-body {
   position: relative;
   width: 100%;

--- a/movieDash/www/js/details/details.js
+++ b/movieDash/www/js/details/details.js
@@ -1,10 +1,10 @@
 angular.module('moviedash.details', [])
 
-.controller('DetailsCtrl', ['$scope', 'selected', function ($scope, selected) {
+.controller('DetailsCtrl', ['$scope', 'selected', '$modal', '$sce', function($scope, selected, $modal, $sce) {
   // Code
   $scope.movie = selected.getStorage('movie');
 
-  $scope.reminderMsg = 'LEAVE REMINDER';
+  $scope.reminderMsg = 'Remind Me to Leave';
   var uniqueMovieId = $scope.movie.id + $scope.movie.showTime + $scope.movie.movieName;
   var alreadyClicked = false;
   var timeoutID;
@@ -18,9 +18,33 @@ angular.module('moviedash.details', [])
     timeoutID = reminderInfo[1];
 
     if (alreadyClicked) {
-      $scope.reminderMsg = 'CLEAR REMINDER';
+      $scope.reminderMsg = 'Don\'t Remind Me';
     }
   }
+
+  $scope.showTrailer = function(movie) {
+    console.log("show trailer");
+    var link = movie.trailerLink;
+    if (link !== false) {
+      var videoId = link.slice(link.indexOf('=') + 1);
+      var embeddedUrl = 'https://www.youtube.com/embed/' + videoId;
+
+      $scope.title = movie.movieName;
+      $scope.trailerUrl = $sce.trustAsResourceUrl(embeddedUrl);
+
+      $scope.$modalInstance = $modal.open({
+        templateUrl: '../../templates/videoplayer.html',
+        controller: 'DetailsCtrl',
+        size: 'lg',
+        scope: $scope
+      });
+    }
+  };
+
+  $scope.closeTrailer = function() {
+    $scope.$modalInstance.close('');
+
+  };
 
   $scope.reminder = function(movie) {
     // HTML 5 Notifications setup
@@ -43,12 +67,12 @@ angular.module('moviedash.details', [])
         var instance = new Notification("Leave now to catch " + movie.movieName+ " at " + movie.showTime + " @ " + movie.theaterAddress);
       }, leaveTime);
 
-      $scope.reminderMsg = 'CLEAR REMINDER';
+      $scope.reminderMsg = 'Don\'t Remind Me';
       alreadyClicked = true;
       $scope.btn = "btn btn-success";
     } else {
       window.clearTimeout(timeoutID);
-      $scope.reminderMsg = 'LEAVE REMINDER';
+      $scope.reminderMsg = 'Remind Me to Leave';
       alreadyClicked = false;
       $scope.btn = "btn btn-primary";
     }

--- a/movieDash/www/js/movies/movies.js
+++ b/movieDash/www/js/movies/movies.js
@@ -62,28 +62,29 @@ angular.module('moviedash.movies', [])
   $scope.movies = developerMode ? stub : MovieClient.getResults().data;
 
 
-  $scope.showTrailer = function(movie) {
-    var link = movie.trailerLink;
-    if (link !== false) {
-      var videoId = link.slice(link.indexOf('=') + 1);
-      var embededUrl = 'https://www.youtube.com/embed/' + videoId;
+  // $scope.showTrailer = function(movie) {
+  //   console.log("show trailer");
+  //   var link = movie.trailerLink;
+  //   if (link !== false) {
+  //     var videoId = link.slice(link.indexOf('=') + 1);
+  //     var embededUrl = 'https://www.youtube.com/embed/' + videoId;
 
-      $scope.title = movie.movieName;
-      $scope.trailerUrl = $sce.trustAsResourceUrl(embededUrl);
+  //     $scope.title = movie.movieName;
+  //     $scope.trailerUrl = $sce.trustAsResourceUrl(embededUrl);
 
-      $scope.$modalInstance = $modal.open({
-        templateUrl: "../App/movies/videoplayer.html",
-        controller: 'MoviesCtrl',
-        size: "lg",
-        scope: $scope
-      });
-    }
-  };
+  //     $scope.$modalInstance = $modal.open({
+  //       templateUrl: "../App/movies/videoplayer.html",
+  //       controller: 'MoviesCtrl',
+  //       size: "lg",
+  //       scope: $scope
+  //     });
+  //   }
+  // };
 
-  $scope.closeTrailer = function() {
-    $scope.$modalInstance.close('');
+  // $scope.closeTrailer = function() {
+  //   $scope.$modalInstance.close('');
 
-  };
+  // };
 
   $scope.getLeaveTime = function() {
     var leaveTime = new Date(selected.getStorage('leavingTime'));

--- a/movieDash/www/templates/details.html
+++ b/movieDash/www/templates/details.html
@@ -1,8 +1,17 @@
+<ion-view view-title="Movie Details">
+<ion-content class="padding light-blue">
+
 <div class="details-panel container">
-  <div class="movie-info center-block row">
-    <img class="img-rounded col-sm-5 col-xs-10 col-xs-offset-1 col-sm-offset-0" ng-src="{{movie.poster}}"/>
-    <div class="col-sm-6 col-sm-offset-1 col-xs-offset-1 col-xs-10">
+  <div>
+    <img ng-src="{{movie.poster}}"/>
+    <div>
       <h1>{{movie.movieName}}</h1>
+   <!--    <div class="video">
+        <img src=""/>
+        <a href="#"></a>
+      </div> -->
+        <button ng-class="btn" ng-disabled="{{ movie.trailerLink === false }}" ng-click="showTrailer(movie)">Show Trailer</button>
+      </div> 
       <p class="lead">{{movie.synopsis}}</p>
       <p ng-if="!movie.synopsis" class="text-muted" > No synopsis available </p>
       <p>Rated: {{movie.rating}}</p>
@@ -10,12 +19,13 @@
       <p>{{movie.theaterAddress}}</p>
       <p class="text-muted">Travel Time: {{movie.transitTime}}</p>
       <h3>Showtime: {{movie.showTime}}</h3>
-      <button class="btn reminder-btn btn-primary hidden-xs" ng-class="btn" ng-click="reminder(movie)">{{ reminderMsg }}</button>
+      <button class="reminder-btn hidden-xs" ng-class="btn" ng-click="reminder(movie)">{{ reminderMsg }}</button>
     </div>
   </div>
 </div>
-<center><div class="col-xs-offset-1 col-xs-10 col-sm-offset-1 col-sm-5" id="directions-panel"></div><center>
-<div class="col-sm-5"><map center="{{origin}}" zoom="8">
+
+<center><div id="directions-panel"></div></center>
+<div><map center="{{origin}}" zoom="8">
   <directions
     draggable="true"
     panel="directions-panel"
@@ -25,3 +35,6 @@
     destination="{{destination}}">
   </directions>
 </map></div>
+
+</ion-content>
+</ion-view>

--- a/movieDash/www/templates/movies.html
+++ b/movieDash/www/templates/movies.html
@@ -28,7 +28,7 @@
 
   </div>
 
-      <!-- <div>
+     <!--  <div>
         <button class="btn btn-trailer btn-primary" ng-disabled="{{ movie.trailerLink === false }}" ng-click="showTrailer(movie)">Show Trailer</button>
       </div> -->
   </div>

--- a/movieDash/www/templates/videoplayer.html
+++ b/movieDash/www/templates/videoplayer.html
@@ -1,4 +1,6 @@
-<div class="modal-header" ng-controller="MoviesCtrl">
+<ion-modal-view>
+<ion-header-bar>
+<div class="modal-header" ng-controller="DetailsCtrl">
   <center><h3 class="modal-title">{{ title }}</h3></center>
 </div>
 <div class="modal-body">
@@ -14,3 +16,5 @@
   <button class="btn btn-primary" type="button" ng-click="closeTrailer()">Close</button>
 </center>
 </div>
+</ion-header-bar>
+</ion-modal-view>


### PR DESCRIPTION
Move video player functionality from movies to the details view

TODO:  Remove "play trailer" button and replace with a play icon overlaying the video image in the details view (cleaner UI for mobile).
